### PR TITLE
Update to use hostname as server ID

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@
 language: go
 
 go:
-  - "1.11"
-  - "1.12"
+  - "1.14"
+  - "1.15"
 
 script:
   - make

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # The (Obscure) Quote of the Moment Service
 
+[![Build Status](https://travis-ci.com/plombardi89/quote.svg?branch=master)](https://travis-ci.com/plombardi89/quote)
+
 Minimal web service that is useful for experiments, tests, and demos. It is inspired by the 
 [Datawire Quote of the Moment](https://github.com/datawire/qotm) service (which I also wrote years ago) but now 
 rewritten in Go and with a slightly different API.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/plombardi89/qotm
 
-go 1.12
+go 1.15
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/main.go
+++ b/main.go
@@ -138,7 +138,7 @@ func main() {
 
 	random := randomzeug.NewRandom()
 	s := Server{
-		id:     generateServerID(random),
+		id:     getServerID(os.Hostname, random),
 		host:   os.Getenv(EnvHOST),
 		port:   port,
 		router: chi.NewRouter(),

--- a/util.go
+++ b/util.go
@@ -170,7 +170,15 @@ var fruits = []string{
 	"tangerine",
 }
 
-func generateServerID(random *randomzeug.Random) string {
+func getServerID(hostnameFunc func() (string, error), random *randomzeug.Random) string {
+	if hostnameFunc == nil {
+		hostnameFunc = os.Hostname
+	}
+
+	if hostname, err := hostnameFunc(); err == nil && hostname != "" {
+		return hostname
+	}
+
 	adjective := random.RandomSelectionFromStringSlice(adjectives)
 	fruit := random.RandomSelectionFromStringSlice(fruits)
 

--- a/util_test.go
+++ b/util_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"errors"
+	"github.com/plombardi89/gozeug/randomzeug"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+)
+
+func Test_getServerID(t *testing.T) {
+	id := getServerID(nil, randomzeug.NewRandom())
+	assert.Equal(t, func() string {
+		v, _ := os.Hostname()
+		return v
+	}(), id)
+
+	id = getServerID(os.Hostname, randomzeug.NewRandom())
+	assert.Equal(t, func() string {
+		v, _ := os.Hostname()
+		return v
+	}(), id)
+
+	id = getServerID(func() (string, error) { return "foo", nil }, randomzeug.NewRandom())
+	assert.Equal(t, "foo", id)
+
+	id = getServerID(func() (string, error) { return "", errors.New("error") }, randomzeug.NewRandom())
+	assert.NotEmpty(t, id)
+}


### PR DESCRIPTION
Use the hostname as the server ID unless it cannot be used for some obscure reason